### PR TITLE
Remove the up-to-date text

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1426,7 +1426,7 @@ impl eframe::App for App {
 					// Is yellow if the user updated and should (but isn't required to) restart.
 					match *lock!(self.restart) {
 						Restart::Yes => ui.add_sized([width, height], Label::new(RichText::new(&self.name_version).color(YELLOW))).on_hover_text(GUPAX_SHOULD_RESTART),
-						_ => ui.add_sized([width, height], Label::new(&self.name_version)).on_hover_text(GUPAX_UP_TO_DATE),
+						_ => ui.add_sized([width, height], Label::new(&self.name_version)),
 					};
 					ui.separator();
 					// [OS]


### PR DESCRIPTION
The message saying that Gupax is up to date is not always true, like if there is a version available but Gupax has not checked for it. Since it is not always true, it would not be good to show this to the users.

Additionally, most users will check the website or the github for the current version info instead.