### PR TITLE
fix: Window "Choose Application" prompt at start (MacOS) #181

### DIFF
--- a/src/helper/notification.rs
+++ b/src/helper/notification.rs
@@ -20,6 +20,9 @@ impl Helper {
     #[inline(never)]
     // The "frontend" function that parses the arguments, and spawns either the [Simple] or [Advanced] Node watchdog thread.
     pub fn start_notifications(helper: &Arc<Mutex<Self>>) {
+        #[cfg(target_os = "macos")]
+        let _ = notify_rust::set_application("com.github.cyrix126.gupax");
+
         let process_node = Arc::clone(&helper.lock().unwrap().node);
         let process_p2pool = Arc::clone(&helper.lock().unwrap().p2pool);
         let process_xmrig = Arc::clone(&helper.lock().unwrap().xmrig);


### PR DESCRIPTION
Fixes #181 

Gupax uses the `notify_rust` crate to send notifications to the user. However, in `notif()`, macOS doesn't respect `appname()`. Despite the [source claiming that calling it is non-operational](https://docs.rs/notify-rust/4.18.0/notify_rust/), it seems to bring up the `use_default` window. The fix is to call the `set_application()` function with the app bundle identifier when the notifications helper is started.