### PR TITLE
fix: p2pool fails to update on ARM based systems #201

### DIFF
--- a/src/components/update.rs
+++ b/src/components/update.rs
@@ -488,8 +488,9 @@ impl Update {
     ) -> Result<(Bytes, String), reqwest::Error> {
         let url = match name {
             "gupax" => Self::standard_download_url(source, name, version),
-            "p2pool" => Self::standard_download_url(source, name, version)
-                .replace("arm64", "aarch64"),
+            "p2pool" => {
+                Self::standard_download_url(source, name, version).replace("arm64", "aarch64")
+            }
             "xmrig" => Self::standard_download_url(source, name, version)
                 .replace("-v", "-")
                 .replace("linux", "linux-static"),

--- a/src/components/update.rs
+++ b/src/components/update.rs
@@ -488,7 +488,8 @@ impl Update {
     ) -> Result<(Bytes, String), reqwest::Error> {
         let url = match name {
             "gupax" => Self::standard_download_url(source, name, version),
-            "p2pool" => Self::standard_download_url(source, name, version),
+            "p2pool" => Self::standard_download_url(source, name, version)
+                .replace("arm64", "aarch64"),
             "xmrig" => Self::standard_download_url(source, name, version)
                 .replace("-v", "-")
                 .replace("linux", "linux-static"),


### PR DESCRIPTION
Fixes #201 

P2Pool uses `aarch64` instead of `arm64` when describing 64-bit ARM systems. This applies to all platforms P2Pool supports so the `replace()` fixes the fetching for all ARM-based systems.